### PR TITLE
refactor: merge into post_repository

### DIFF
--- a/backend/internal/controllers/post_get_detail_test.go
+++ b/backend/internal/controllers/post_get_detail_test.go
@@ -42,6 +42,10 @@ func (p *DummyPostGetDetailRepository) GetDetail(id int) (*entities.Post, error)
 	}
 }
 
+func (p *DummyPostGetDetailRepository) GetList() ([]entities.Post, error) {
+	return nil, nil
+}
+
 func TestPostGetDetail(t *testing.T) {
 	repository := NewDummyPostGetDetailRepository()
 	DummyPostGetDetails := []entities.Post{

--- a/backend/internal/controllers/post_get_list_test.go
+++ b/backend/internal/controllers/post_get_list_test.go
@@ -26,6 +26,10 @@ func (p *DummyPostGetListRepository) SetPosts(posts []entities.Post) {
 	p.Posts = posts
 }
 
+func (p *DummyPostGetListRepository) GetDetail(id int) (*entities.Post, error) {
+	return nil, nil
+}
+
 func (p *DummyPostGetListRepository) GetList() ([]entities.Post, error) {
 	if p.Posts != nil {
 		return p.Posts, nil

--- a/backend/internal/interfaces/post_get_list_repository.go
+++ b/backend/internal/interfaces/post_get_list_repository.go
@@ -1,9 +1,0 @@
-package interfaces
-
-import (
-	"myapp/internal/entities"
-)
-
-type PostGetListRepository interface {
-	GetList() ([]entities.Post, error)
-}

--- a/backend/internal/interfaces/post_repository.go
+++ b/backend/internal/interfaces/post_repository.go
@@ -4,6 +4,7 @@ import (
 	"myapp/internal/entities"
 )
 
-type PostGetDetailRepository interface {
+type PostRepository interface {
+	GetList() ([]entities.Post, error)
 	GetDetail(id int) (*entities.Post, error)
 }

--- a/backend/internal/usecases/post_get_detail.go
+++ b/backend/internal/usecases/post_get_detail.go
@@ -6,10 +6,10 @@ import (
 )
 
 type PostGetDetailUsecase struct {
-	repository interfaces.PostGetDetailRepository
+	repository interfaces.PostRepository
 }
 
-func NewPostGetDetailUsecase(r interfaces.PostGetDetailRepository) *PostGetDetailUsecase {
+func NewPostGetDetailUsecase(r interfaces.PostRepository) *PostGetDetailUsecase {
 	return &PostGetDetailUsecase{
 		repository: r,
 	}

--- a/backend/internal/usecases/post_get_list_usecase.go
+++ b/backend/internal/usecases/post_get_list_usecase.go
@@ -6,10 +6,10 @@ import (
 )
 
 type PostGetListUsecase struct {
-	repository interfaces.PostGetListRepository
+	repository interfaces.PostRepository
 }
 
-func NewPostGetListUsecase(r interfaces.PostGetListRepository) *PostGetListUsecase {
+func NewPostGetListUsecase(r interfaces.PostRepository) *PostGetListUsecase {
 	return &PostGetListUsecase{
 		repository: r,
 	}


### PR DESCRIPTION
close #27 

entityのrepositoryをまとめる。

ただ、これやるとテストでダミーのレポジトリ作るときに不要なメソッドまで定義しなきゃいけなくなる。