### PR TITLE
implement signout api

### DIFF
--- a/backend/internal/controllers/auth_signout.go
+++ b/backend/internal/controllers/auth_signout.go
@@ -1,0 +1,17 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func AuthSignout(ctx *gin.Context) {
+	token, err := ctx.Cookie("jwt")
+	if err != nil {
+		handleError(ctx, http.StatusBadRequest, err)
+		return
+	}
+	ctx.SetCookie("jwt", token, 0, "/", "localhost", false, false)
+	ctx.Status(http.StatusNoContent)
+}

--- a/backend/internal/dependency/container.go
+++ b/backend/internal/dependency/container.go
@@ -31,3 +31,7 @@ func (di *DIContainer) AuthSigninController(ctx *gin.Context) {
 	usecase := usecases.NewAuthSigninUsecase(repository)
 	controllers.AuthSignin(ctx, usecase)
 }
+
+func (di *DIContainer) AuthSignoutController(ctx *gin.Context) {
+	controllers.AuthSignout(ctx)
+}

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -17,7 +17,10 @@ func SetupRoutes(app *gin.Engine) {
 	app.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
 
 	container := dependency.NewDIContainer()
+
 	app.GET("/posts", container.PostGetListController)
 	app.GET("/posts/:postId", container.PostGetDetailController)
+
 	app.POST("/signin", container.AuthSigninController)
+	app.POST("/signout", container.AuthSignoutController)
 }


### PR DESCRIPTION
close #23

以下のスクリプトで動作確認できます。

```bash
$ curl -v -c cookie.txt -d '{"username":"taro","password":"password"}' http://localhost:9000/signin
$ curl -v -X POST -b cookie.txt -c - http://localhost:9000/signout
```
