### PR TITLE
fix path of post-detail API

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -15,7 +15,39 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/post/{postID}": {
+        "/posts": {
+            "get": {
+                "description": "投稿一覧を取得します",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "posts"
+                ],
+                "summary": "get list posts",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/entities.Post"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/posts/{postID}": {
             "get": {
                 "description": "投稿の詳細を取得します",
                 "consumes": [
@@ -54,38 +86,6 @@ const docTemplate = `{
                         "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/controllers.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/posts": {
-            "get": {
-                "description": "投稿一覧を取得します",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "posts"
-                ],
-                "summary": "get list posts",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/entities.Post"
-                            }
                         }
                     },
                     "500": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -9,7 +9,39 @@
     "host": "localhost:9000",
     "basePath": "/",
     "paths": {
-        "/post/{postID}": {
+        "/posts": {
+            "get": {
+                "description": "投稿一覧を取得します",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "posts"
+                ],
+                "summary": "get list posts",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/entities.Post"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/posts/{postID}": {
             "get": {
                 "description": "投稿の詳細を取得します",
                 "consumes": [
@@ -48,38 +80,6 @@
                         "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/controllers.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/posts": {
-            "get": {
-                "description": "投稿一覧を取得します",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "posts"
-                ],
-                "summary": "get list posts",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/entities.Post"
-                            }
                         }
                     },
                     "500": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -71,7 +71,28 @@ info:
   title: web-application team 5 API
   version: "1.0"
 paths:
-  /post/{postID}:
+  /posts:
+    get:
+      consumes:
+      - application/json
+      description: 投稿一覧を取得します
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/entities.Post'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controllers.ErrorResponse'
+      summary: get list posts
+      tags:
+      - posts
+  /posts/{postID}:
     get:
       consumes:
       - application/json
@@ -102,27 +123,6 @@ paths:
           schema:
             $ref: '#/definitions/controllers.ErrorResponse'
       summary: get post detail
-      tags:
-      - posts
-  /posts:
-    get:
-      consumes:
-      - application/json
-      description: 投稿一覧を取得します
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/entities.Post'
-            type: array
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/controllers.ErrorResponse'
-      summary: get list posts
       tags:
       - posts
   /signin:

--- a/backend/internal/controllers/post_get_detail.go
+++ b/backend/internal/controllers/post_get_detail.go
@@ -20,7 +20,7 @@ import (
 // @Failure	400		{object}	controllers.ErrorResponse
 // @Failure	404		{object}	controllers.ErrorResponse
 // @Failure	500		{object}	controllers.ErrorResponse
-// @Router	/post/{postID}	[get]
+// @Router	/posts/{postID}	[get]
 func PostGetDetail(ctx *gin.Context, usecase *usecases.PostGetDetailUsecase) {
 	if usecase == nil {
 		handleError(ctx, http.StatusInternalServerError, errors.New("ぬるぽ"))


### PR DESCRIPTION
fix #49

なんか自動生成の際に全件取得の方と順番が入れ替わって色々変更されてるみたいになってますが、実際の変更は`/post/{postID}` -> `/posts/{postID}`だけです
