### PR TITLE
.envの読み取りエラー解消

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
 .PHONY: swag
 swag:
 	docker-compose exec backend sh -c "swag init --requiredByDefault"
+test:
+	cd backend && IS_TEST=1 go test ./...

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ swaggerファイルの再生成は以下のコマンドを実行してくださ�
 make swag
 ```
 
+## How to test go
+```
+make test
+```
+
 ### how to write doc
 
 1. 各endpointに対応する関数(controllers層)に対して記述してください。

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -45,8 +45,15 @@ func init() {
 	if v := os.Getenv("AUTH_SECRET_KEY"); v != "" {
 		AuthSecretKey = v
 	} else {
+		// テスト時はスキップ
+		if is := os.Getenv("IS_TEST"); is == "1" {
+			return
+		}
 		// localなら.envから読み込む
-		godotenv.Load()
+		err := godotenv.Load()
+		if err != nil {
+			panic(err)
+		}
 		AuthSecretKey = os.Getenv("SECRET_KEY")
 	}
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -45,11 +45,8 @@ func init() {
 	if v := os.Getenv("AUTH_SECRET_KEY"); v != "" {
 		AuthSecretKey = v
 	} else {
-		// load .env only local
-		err := godotenv.Load("../../.env")
-		if err != nil {
-			panic("Error loading .env file")
-		}
+		// localなら.envから読み込む
+		godotenv.Load()
 		AuthSecretKey = os.Getenv("SECRET_KEY")
 	}
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -52,7 +52,7 @@ func init() {
 		// localなら.envから読み込む
 		err := godotenv.Load()
 		if err != nil {
-			panic(err)
+			panic("Error loading .env file")
 		}
 		AuthSecretKey = os.Getenv("SECRET_KEY")
 	}


### PR DESCRIPTION
## 概要
.envファイルの読み込みがエラーになるの解消
- ローカルでは.envファイルから読み込むように
- テスト時は、.envファイルの読み込みをskip

## テスト手順
- APIが叩ける
- `make test`が通る
```bash
make test
?   	myapp	[no test files]
?   	myapp/docs	[no test files]
?   	myapp/internal/config	[no test files]
?   	myapp/internal/constant	[no test files]
?   	myapp/internal/dependency	[no test files]
?   	myapp/internal/entity	[no test files]
?   	myapp/internal/external	[no test files]
?   	myapp/internal/interfaces	[no test files]
?   	myapp/internal/middleware	[no test files]
?   	myapp/internal/repository	[no test files]
?   	myapp/internal/repository/model	[no test files]
?   	myapp/internal/usecase	[no test files]
ok  	myapp/internal/controller	0.667s
```