### PR TITLE
Feat/post like

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -659,6 +659,7 @@ const docTemplate = `{
                 "comments",
                 "created_at",
                 "id",
+                "like_count",
                 "title",
                 "updated_at",
                 "user_id",
@@ -679,6 +680,9 @@ const docTemplate = `{
                     "format": "date-time"
                 },
                 "id": {
+                    "type": "integer"
+                },
+                "like_count": {
                     "type": "integer"
                 },
                 "title": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -652,6 +652,7 @@
                 "comments",
                 "created_at",
                 "id",
+                "like_count",
                 "title",
                 "updated_at",
                 "user_id",
@@ -672,6 +673,9 @@
                     "format": "date-time"
                 },
                 "id": {
+                    "type": "integer"
+                },
+                "like_count": {
                     "type": "integer"
                 },
                 "title": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -103,6 +103,8 @@ definitions:
         type: string
       id:
         type: integer
+      like_count:
+        type: integer
       title:
         type: string
       updated_at:
@@ -117,6 +119,7 @@ definitions:
     - comments
     - created_at
     - id
+    - like_count
     - title
     - updated_at
     - user_id

--- a/backend/internal/controller/post_get_detail_test.go
+++ b/backend/internal/controller/post_get_detail_test.go
@@ -28,7 +28,7 @@ func (p *DummyPostGetDetailRepository) SetPosts(posts []entity.Post) {
 	p.Posts = posts
 }
 
-func (p *DummyPostGetDetailRepository) GetDetail(id uint, includeComments bool) (*entity.Post, error) {
+func (p *DummyPostGetDetailRepository) GetDetail(id uint, includeCommentsAndLikeCount bool) (*entity.Post, error) {
 	if p.Posts == nil {
 		return nil, errors.New("database broken")
 	} else {

--- a/backend/internal/entity/post.go
+++ b/backend/internal/entity/post.go
@@ -9,6 +9,7 @@ type Post struct {
 	UserID    uint      `json:"user_id"`
 	Username  string    `json:"username"`
 	Comments  []Comment `json:"comments"`
+	LikeCount uint      `json:"like_count"`
 	CreatedAt time.Time `json:"created_at" format:"date-time"`
 	UpdatedAt time.Time `json:"updated_at" format:"date-time"`
 }

--- a/backend/internal/external/mysql.go
+++ b/backend/internal/external/mysql.go
@@ -7,6 +7,7 @@ import (
 
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 var DB *gorm.DB
@@ -27,5 +28,6 @@ func SetupDB() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	db.Logger = db.Logger.LogMode(logger.Info)
 	DB = db
 }

--- a/backend/internal/external/mysql.go
+++ b/backend/internal/external/mysql.go
@@ -22,7 +22,7 @@ func SetupDB() {
 		username += ":" + config.DBPassword
 	}
 	dsn := fmt.Sprintf("%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local", username, host, port, dbname)
-	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{ TranslateError: true })
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{TranslateError: true})
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/backend/internal/interfaces/post_get_detail_repository.go
+++ b/backend/internal/interfaces/post_get_detail_repository.go
@@ -7,5 +7,5 @@ import (
 type PostGetDetailRepository interface {
 	// idに該当するpostがないとき、返り値は (nil, nil) になる。
 	// errorはこれ以外の内部エラーが起きたときだけ入る。
-	GetDetail(id uint, includeComments bool) (*entity.Post, error)
+	GetDetail(id uint, includeCommentsAndLikeCount bool) (*entity.Post, error)
 }

--- a/backend/internal/repository/model/post.go
+++ b/backend/internal/repository/model/post.go
@@ -11,11 +11,16 @@ type Post struct {
 	Title    string
 	Body     string
 	UserID   uint
-	User     User
 	Comments []Comment
 }
 
-func ConvertPostModelToEntity(p *Post) *entity.Post {
+type PostWith struct {
+	Post
+	UserName  string
+	LikeCount uint
+}
+
+func ConvertPostModelToEntity(p *PostWith) *entity.Post {
 	comments := make([]entity.Comment, len(p.Comments))
 	for i, c := range p.Comments {
 		comments[i] = *ConvertCommentModelToEntity(&c)
@@ -25,8 +30,9 @@ func ConvertPostModelToEntity(p *Post) *entity.Post {
 		Title:     p.Title,
 		Body:      p.Body,
 		UserID:    p.UserID,
-		Username:  p.User.Name,
 		Comments:  comments,
+		Username:  p.UserName,
+		LikeCount: p.LikeCount,
 		CreatedAt: p.CreatedAt,
 		UpdatedAt: p.UpdatedAt,
 	}

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -18,9 +18,17 @@ func NewPostRepository(conn *gorm.DB) *PostRepository {
 	}
 }
 
+// いいね数は含むが、コメントは空で返す
 func (p *PostRepository) GetList() ([]entity.Post, error) {
-	var obj []model.Post
-	result := p.Conn.Order("id desc").Preload("User").Find(&obj)
+	var obj []model.PostWith
+	result := p.Conn.Debug().
+		Model(&model.Post{}).
+		Select("posts.*, users.name AS user_name, COUNT(likes.id) AS like_count").
+		Joins("LEFT JOIN likes ON posts.id = likes.post_id").
+		Joins("LEFT JOIN users ON posts.user_id = users.id").
+		Group("posts.id").
+		Order("posts.id DESC").
+		Scan(&obj)
 	if result.Error != nil {
 		return nil, result.Error
 	}
@@ -32,15 +40,33 @@ func (p *PostRepository) GetList() ([]entity.Post, error) {
 	return posts, nil
 }
 
-func (p *PostRepository) GetDetail(postID uint, includeComments bool) (*entity.Post, error) {
-	var obj model.Post
-	var err error
-	if includeComments {
-		err = p.Conn.Preload("Comments", func(db *gorm.DB) *gorm.DB {
-			return db.Order("comments.id ASC")
-		}).Preload("User").Where("id = ?", postID).First(&obj).Error
+func (p *PostRepository) GetDetail(postID uint, includeCommentsAndLikeCount bool) (*entity.Post, error) {
+	var (
+		post model.PostWith
+		err  error
+	)
+	if includeCommentsAndLikeCount {
+		err = p.Conn.Debug().
+			Model(&model.Post{}).
+			Select("posts.*, users.name AS user_name, COUNT(likes.id) AS like_count").
+			Where("posts.id = ?", postID).
+			Joins("LEFT JOIN likes ON posts.id = likes.post_id").
+			Joins("LEFT JOIN users ON posts.user_id = users.id").
+			Group("posts.id").
+			Scan(&post).Error
+		if err == nil {
+			err = p.Conn.Debug().
+				Model(&model.Comment{}).
+				Where("post_id = ?", postID).
+				Scan(&post.Comments).Error
+		}
 	} else {
-		err = p.Conn.Preload("User").Where("id = ?", postID).First(&obj).Error
+		err = p.Conn.Debug().
+			Model(&model.Post{}).
+			Select("posts.*, users.name AS user_name").
+			Joins("LEFT JOIN users ON posts.user_id = users.id").
+			Where("posts.id = ?", postID).
+			Scan(&post).Error
 	}
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -48,7 +74,7 @@ func (p *PostRepository) GetDetail(postID uint, includeComments bool) (*entity.P
 		}
 		return nil, err
 	}
-	return model.ConvertPostModelToEntity(&obj), nil
+	return model.ConvertPostModelToEntity(&post), nil
 }
 
 func (p *PostRepository) PostNew(userID uint, title, body string) error {

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -21,7 +21,7 @@ func NewPostRepository(conn *gorm.DB) *PostRepository {
 // いいね数は含むが、コメントは空で返す
 func (p *PostRepository) GetList() ([]entity.Post, error) {
 	var obj []model.PostWith
-	result := p.Conn.Debug().
+	result := p.Conn.
 		Model(&model.Post{}).
 		Select("posts.*, users.name AS user_name, COUNT(likes.id) AS like_count").
 		Joins("LEFT JOIN likes ON posts.id = likes.post_id").
@@ -46,7 +46,7 @@ func (p *PostRepository) GetDetail(postID uint, includeCommentsAndLikeCount bool
 		err  error
 	)
 	if includeCommentsAndLikeCount {
-		err = p.Conn.Debug().
+		err = p.Conn.
 			Model(&model.Post{}).
 			Select("posts.*, users.name AS user_name, COUNT(likes.id) AS like_count").
 			Where("posts.id = ?", postID).
@@ -61,7 +61,7 @@ func (p *PostRepository) GetDetail(postID uint, includeCommentsAndLikeCount bool
 				Scan(&post.Comments).Error
 		}
 	} else {
-		err = p.Conn.Debug().
+		err = p.Conn.
 			Model(&model.Post{}).
 			Select("posts.*, users.name AS user_name").
 			Joins("LEFT JOIN users ON posts.user_id = users.id").

--- a/backend/internal/usecase/post_get_detail.go
+++ b/backend/internal/usecase/post_get_detail.go
@@ -17,6 +17,6 @@ func NewPostGetDetailUsecase(r interfaces.PostGetDetailRepository) *PostGetDetai
 
 // idに該当するpostがないとき、返り値は (nil, nil) になる。
 // errorはこれ以外の内部エラーが起きたときだけ入る。
-func (p *PostGetDetailUsecase) Execute(id uint, includeComments bool) (*entity.Post, error) {
-	return p.repository.GetDetail(id, includeComments)
+func (p *PostGetDetailUsecase) Execute(id uint, includeCommentsAndLikeCount bool) (*entity.Post, error) {
+	return p.repository.GetDetail(id, includeCommentsAndLikeCount)
 }


### PR DESCRIPTION
close #81 

割とやばい実装だけどとりあえず動く。
Joinsを使うとPreloadが効かなくなるので、like_countとuser_nameを同時に取るためにLEFT JOINを2つ書くことになってしまった。

## 発行されるSQL

post-get-detail
```sql
SELECT posts.*, users.name AS user_name, COUNT(likes.id) AS like_count FROM `posts` LEFT JOIN likes ON posts.id = likes.post_id LEFT JOIN users ON posts.user_id = users.id WHERE posts.id = 1 AND `posts`.`deleted_at` IS NULL GROUP BY `posts`.`id`;

SELECT * FROM `comments` WHERE post_id = 1 AND `comments`.`deleted_at` IS NULL;
```

post-list
```sql
SELECT posts.*, users.name AS user_name, COUNT(likes.id) AS like_count FROM `posts` LEFT JOIN likes ON posts.id = likes.post_id LEFT JOIN users ON posts.user_id = users.id WHERE `posts`.`deleted_at` IS NULL GROUP BY `posts`.`id` ORDER BY posts.id DESC;
```